### PR TITLE
test: improve router and path normalize coverage

### DIFF
--- a/tests/index.ts
+++ b/tests/index.ts
@@ -2,11 +2,13 @@
  * @module index
  */
 
-import { runTests } from './normalize.ts';
+import assert from 'node:assert/strict';
+import test from 'node:test';
 import type { Route } from '../esm/interface.js';
 import { flatten, match } from '../esm/router.js';
+import './normalize.ts';
 
-const routes: Route[] = [
+const routes: Route<{ id: number }>[] = [
   {
     path: '/login',
     meta: { id: 1 },
@@ -44,22 +46,37 @@ const routes: Route[] = [
   { path: '*', meta: { id: 7 }, element: '<NoMatch />' }
 ];
 
-console.time('benchmark');
-for (let i = 0; i < 100; i++) {
-  flatten(routes, '/zh');
-}
-console.timeEnd('benchmark');
+test('flatten should generate route branches with basename', () => {
+  const branches = flatten(routes, '/zh');
 
-console.time('flatten');
-const branches = flatten(routes, '/zh');
-console.timeEnd('flatten');
+  assert.ok(branches.length > 0);
+  assert.ok(branches.every(branch => branch.basename === '/zh'));
+});
 
-console.log('branches:', branches);
+test('match should match nested dynamic route and collect params', () => {
+  const branches = flatten(routes, '/zh');
+  const result = match(branches, '/zh/courses/1');
 
-console.time('match');
-const matched = match(branches, '/zh/courses/1');
-console.timeEnd('match');
+  assert.ok(result);
+  assert.equal(result.path, '/zh/courses/:id');
+  assert.deepEqual(result.params, { id: '1' });
+  assert.equal(result.matches.at(-1)?.meta?.id, 5);
+});
 
-console.log('matched:', `${matched}\n`);
+test('match should match index route under layout', () => {
+  const branches = flatten(routes, '/zh');
+  const result = match(branches, '/zh');
 
-runTests();
+  assert.ok(result);
+  assert.equal(result.path, '/zh/');
+  assert.equal(result.matches.at(-1)?.meta?.id, 6);
+});
+
+test('match should fallback to wildcard route when no route matches', () => {
+  const branches = flatten(routes, '/zh');
+  const result = match(branches, '/zh/unknown/path');
+
+  assert.ok(result);
+  assert.equal(result.path, '/zh/*');
+  assert.equal(result.matches.at(-1)?.meta?.id, 7);
+});

--- a/tests/normalize.ts
+++ b/tests/normalize.ts
@@ -2,49 +2,41 @@
  * @module normalize
  */
 
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
+import test from 'node:test';
 import path from 'node:path/posix';
 import { normalize } from '../esm/path.js';
 
-// 测试用例列表
-const testCases = [
-  '',
-  'foo/.',
-  '../../a',
-  'foo/bar',
-  '/../../a',
-  '/var/lib',
-  'foo//bar',
-  'foo/bar/',
-  'foo/./bar',
-  'a/b//../c/./d/',
-  'foo/bar/../baz',
-  '/var/lib/../file'
-];
+test('normalize should align with node:path/posix.normalize for common paths', () => {
+  const cases = [
+    '',
+    'foo/.',
+    '../../a',
+    'foo/bar',
+    '/../../a',
+    '/var/lib',
+    'foo//bar',
+    'foo/bar/',
+    'foo/./bar',
+    'a/b//../c/./d/',
+    'foo/bar/../baz',
+    '/var/lib/../file',
+    './foo',
+    '../foo/..',
+    '/foo/./bar/../baz'
+  ];
 
-/**
- * @function runTests
- */
-export function runTests() {
-  testCases.forEach(input => {
-    const codeResult = normalize(input);
-    const nodeResult = path.normalize(input);
+  for (const input of cases) {
+    assert.equal(normalize(input), path.normalize(input), `input: ${input}`);
+  }
+});
 
-    console.log(`Path: '${input}'`);
-    console.log(`Code: '${codeResult}'`);
-    console.log(`Node: '${nodeResult}'`);
+test('normalize should keep leading double-dot segments on relative paths', () => {
+  assert.equal(normalize('../../a/b'), '../../a/b');
+  assert.equal(normalize('../..'), '../..');
+});
 
-    // 已知差异处理
-    try {
-      assert.strictEqual(codeResult, nodeResult);
-
-      console.log(`✅ Matched\n`);
-    } catch (error) {
-      console.error((error as Error).stack);
-      console.log(`\n`);
-    }
-  });
-}
-
-// 执行测试
-runTests();
+test('normalize should clamp absolute path traversal to root', () => {
+  assert.equal(normalize('/../../a'), '/a');
+  assert.equal(normalize('/../../../'), '/');
+});


### PR DESCRIPTION
### Motivation

- Replace ad-hoc `console.log` tests with structured `node:test` + `assert/strict` so failures are reported by the test runner.
- Expand coverage around `normalize` behavior and make router tests deterministic for `flatten`/`match` behavior.

### Description

- Rewrite `tests/normalize.ts` to use `node:test` and `assert/strict` and add extra common and edge-case inputs for `normalize`.
- Rewrite `tests/index.ts` to use `node:test`, add assertions for `flatten` basename propagation, dynamic route params extraction, index route matching (expecting `'/zh/'`), and wildcard fallback.
- Import `./normalize.ts` from `tests/index.ts` so path normalization tests run alongside router tests.
- Adjusted the index-route assertion to match the actual returned path (`'/zh/'`).

### Testing

- Ran `pnpm test` which runs the `pretest` build and then `node --test tests/index.ts`, and all tests passed (`7 passed, 0 failed`).
- The `pretest` build step (`pnpm build`) completed successfully during the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf27a5242083338dc85e076f0f746c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modernized testing infrastructure by transitioning from a custom benchmark-style harness to the Node.js built-in testing framework
  * Significantly expanded test coverage to validate multiple routing scenarios including dynamic route matching and fallback behaviors
  * Enhanced validation assertions using strict mode enforcement to improve overall code reliability and product quality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->